### PR TITLE
Fix fetching data of Wakatime stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This script depends on the Cache.js script (above) from [EvanDColeman](https://g
 // TODO: PLEASE SET THESE VALUES
 const YOURNAME = 'TODO';
 const WAKAUSER = 'TODO';
+const API_KEY = 'TODO'; // Your wakatime API KEY from https://wakatime.com/api-key   
 ```
 
 You may also set up [automations in Shortcuts](https://support.apple.com/guide/shortcuts/create-a-new-personal-automation-apdfbdbd7123/ios) to run this script, to check for updates at times other than the ones dictated by Scriptable's normal widget refresh interval.

--- a/src/WakaStats.js
+++ b/src/WakaStats.js
@@ -152,8 +152,10 @@ async function fetchData() {
 async function fetchWaka() {
 
   const url = "https://wakatime.com/api/v1/users/" + WAKAUSER + "/stats/" + DATERANGE;
+  const key = Data.fromString(API_KEY).toBase64String();
+  const headers = {Authorization: `Basic ${key}`};
 
-  const data = await fetchJson(url);
+  const data = await fetchJson(url, headers);
 
   if (!data) {
     return 'No data found';
@@ -182,8 +184,8 @@ async function fetchWaka() {
 
 async function fetchJson(url, headers) {
   try {
-    console.log('Fetching url: ${url}');
-    const req = new Request(url);
+    console.log(`Fetching url: ${url}`);
+    const req = new Request(url, headers);
     req.headers = headers;
     const resp = await req.loadJSON();
     return resp;

--- a/src/WakaStats.js
+++ b/src/WakaStats.js
@@ -27,6 +27,7 @@ const COLORS = {
 // TODO: PLEASE SET THESE VALUES
 const YOURNAME = 'TODO';
 const WAKAUSER = 'TODO'; // Your wakatime username
+const API_KEY = 'TODO'; // Your wakatime API KEY from https://wakatime.com/api-key
 
 /******************************************************************************
  * Initial Setups


### PR DESCRIPTION
### Problem   
issue #7 occurrs When I read and follow README.md(Copy and Paste, Run the WakaStats.js).   
   
![IMG_error](https://user-images.githubusercontent.com/70031788/194342131-da6a2c87-52e9-46a2-9a38-151b24a8329c.jpeg)
It seems that Unauthorized requests are forbidden. It requires access token or API KEY.
   
### Fix   
Wakatime API Docs says that users who wants to get data by using API need an authentication to access own data.
I fixed this issue by sending GET request with API KEY. 
1. Add own API KEY value.
2. Make header with base64 encoded API KEY for authorization.
3. Send request with header.    
   
![IMG_fixed](https://user-images.githubusercontent.com/70031788/194345334-c57b7f1f-1006-498f-9031-4fe05ad713f4.jpeg)


